### PR TITLE
fix: add condition to show the resume icon

### DIFF
--- a/duel/src/Components/Layouts/Main.style.js
+++ b/duel/src/Components/Layouts/Main.style.js
@@ -577,6 +577,7 @@ export const FlickityContainer = styled.div.attrs({
 
 export const ProfileWrapper = styled.div.attrs({ className: "flex" })`
   position: relative;
+  margin-bottom: 30px;
   .image {
     position: relative;
     img {

--- a/duel/src/Components/Layouts/Team.js
+++ b/duel/src/Components/Layouts/Team.js
@@ -83,16 +83,20 @@ export default class Team extends Component {
                         title={`View ${name}'s Linkedin profile`}
                       />
                     </a>
-                    <a
-                     href={require(`../../assets/resumes/${resumeTitle}.pdf`)}
+                    {
+                      resumeTitle &&
+                      <a
+                      href={require(`../../assets/resumes/${resumeTitle}.pdf`)}
                       rel="noreferrer noopener"
                       target="_blank"
-                    >
+                      >
                       <img
                         src={require('../../assets/profiles/cv.png')}
                         title={`View ${name}'s resume`}
-                      />
+                        alt={`View ${name}'s resume`}
+                        />
                     </a>
+                      }
                   </div>
                 </ProfileDescr>
               </ProfileWrapper>


### PR DESCRIPTION
fix the error in team pages that don't contain a resume link by adding a condition
and fix the overlying sections in team page